### PR TITLE
Add commas that were missing in list of test input strings

### DIFF
--- a/src/brutus-module-weather/brutus_module_weather/tests/cloudQuestion_test.py
+++ b/src/brutus-module-weather/brutus_module_weather/tests/cloudQuestion_test.py
@@ -13,9 +13,9 @@ class CloudTestCase(BrutusTestCase):
     """
 
     cloudQuestions = ['Is it cloudy',
-                      'Are there a lot of clouds'
-                      'How many clouds are there'
-                      'hOW MANY CLOUDS ARE THere'
+                      'Are there a lot of clouds',
+                      'How many clouds are there',
+                      'hOW MANY CLOUDS ARE THere',
                       'Tell me about the clouds']
 
     def test_basic_clouds_questions(self):


### PR DESCRIPTION
Commas were missing in list of test inputs for the weather module so python concatenates the strings
This was not creating errors but could cause different behavior than expected down the road