### PR TITLE
Add support for request sessions.

### DIFF
--- a/src/brutus-api/brutus_api/schema.sql
+++ b/src/brutus-api/brutus_api/schema.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS module (
 CREATE TABLE IF NOT EXISTS session (
     id INTEGER PRIMARY KEY,
     module_id INTEGER,
+    module_data TEXT,
     status TEXT NOT NULL,
     FOREIGN KEY (module_id) REFERENCES module(id)
 );

--- a/src/brutus-api/brutus_api/schema.sql
+++ b/src/brutus-api/brutus_api/schema.sql
@@ -4,12 +4,19 @@ CREATE TABLE IF NOT EXISTS module (
     url TEXT
 );
 
+CREATE TABLE IF NOT EXISTS session (
+    id INTEGER PRIMARY KEY,
+    module_id INTEGER,
+    status TEXT NOT NULL,
+    FOREIGN KEY (module_id) REFERENCES module(id)
+);
+
 CREATE TABLE IF NOT EXISTS request (
     id INTEGER PRIMARY KEY,
     job_id TEXT,
-    module_id INTEGER,
+    session_id INTEGER NOT NULL,
     status TEXT NOT NULL,
     input TEXT NOT NULL,
     output TEXT,
-    FOREIGN KEY (module_id) REFERENCES module(id)
+    FOREIGN KEY (session_id) REFERENCES session(id)
 );

--- a/src/brutus-api/brutus_api/tasks.py
+++ b/src/brutus-api/brutus_api/tasks.py
@@ -61,10 +61,10 @@ def process_request(request_id):
     if module is None:
         raise RuntimeError("module {0} not found".format(module_name))
 
-    # update the request module
+    # update the session module
     db.execute(
-        'UPDATE request SET module_id = ? WHERE id = ?',
-        (module['id'], request_id))
+        'UPDATE session SET module_id = ? WHERE id = ?',
+        (module['id'], request['session_id']))
 
     db.commit()
 

--- a/src/brutus-api/brutus_api/tasks.py
+++ b/src/brutus-api/brutus_api/tasks.py
@@ -38,6 +38,17 @@ def process_request(request_id):
     if request is None:
         raise RuntimeError("request {0} not found".format(request_id))
 
+    # get the current session
+    session_id = request['session_id']
+    session = query_db(
+        db,
+        'SELECT * FROM session WHERE id = ?',
+        (session_id, ),
+        single=True)
+
+    if session is None:
+        raise RuntimeError("session {0} not found".format(session_id))
+
     # update the request status
     db.execute(
         'UPDATE request SET status = \'started\' WHERE id = ?',
@@ -45,35 +56,52 @@ def process_request(request_id):
 
     db.commit()
 
-    # classify the module using the natural language classifier
-    nlc = Nlc(
-        app.config['NLC_WATSON_USERNAME'],
-        app.config['NLC_WATSON_PASSWORD'],
-        app.config['NLC_CLASSIFIER_NAME'])
+    # check if we need to classify the module
+    if session['module_id'] is None:
+        # classify the module using the natural language classifier
+        nlc = Nlc(
+            app.config['NLC_WATSON_USERNAME'],
+            app.config['NLC_WATSON_PASSWORD'],
+            app.config['NLC_CLASSIFIER_NAME'])
 
-    module_name = nlc.classify(request['input'])
-    module = query_db(
-        db,
-        'SELECT * FROM module WHERE name = ?',
-        (module_name, ),
-        single=True)
+        module_name = nlc.classify(request['input'])
+        module = query_db(
+            db,
+            'SELECT * FROM module WHERE name = ?',
+            (module_name, ),
+            single=True)
 
-    if module is None:
-        raise RuntimeError("module {0} not found".format(module_name))
+        if module is None:
+            raise RuntimeError(
+                "module with name {0} not found".format(module_name))
 
-    # update the session module
-    db.execute(
-        'UPDATE session SET module_id = ? WHERE id = ?',
-        (module['id'], request['session_id']))
+        # update the session module
+        db.execute(
+            'UPDATE session SET module_id = ? WHERE id = ?',
+            (module['id'], session_id))
 
-    db.commit()
+        db.commit()
+    # retrieve the session module
+    else:
+        module = query_db(
+            db,
+            'SELECT * FROM module WHERE id = ?',
+            (session['module_id'], ),
+            single=True)
+
+        if module is None:
+            raise RuntimeError(
+                "module {0} not found".format(session['module_id']))
 
     # query the module
-    r = requests.post(
-        "{0}/api/request".format(module['url']),
-        json={'input': {'text': request['input']}})
+    request_data = {'input': {'text': request['input']}, 'data': {}}
+    if session['module_data'] is not None:
+        request_data['data'] = json.loads(session['module_data'])
 
-    if r.text is not None:
+    module_url = "{0}/api/request".format(module['url'])
+    response = requests.post(module_url, json=request_data)
+
+    if response.text is not None:
         result = json.loads(r.text)
         output = result['output']
 

--- a/src/brutus-api/brutus_api/views/__init__.py
+++ b/src/brutus-api/brutus_api/views/__init__.py
@@ -1,3 +1,4 @@
 from .general import index
 from .modules import modules, get_module, delete_module
+from .sessions import sessions, get_session
 from .requests import requests, get_request

--- a/src/brutus-api/brutus_api/views/modules.py
+++ b/src/brutus-api/brutus_api/views/modules.py
@@ -1,7 +1,6 @@
-from flask import g, request, render_template, json, abort
+from flask import g, request, json, abort
 
 from brutus_api.app import app
-from brutus_api.tasks import process_request
 from brutus_api.database import query_db, insert_db
 
 
@@ -46,7 +45,7 @@ def get_module(mod_id):
         single=True)
 
     if module is None:
-        # request not found
+        # module not found
         abort(404)
 
     # return the module data
@@ -67,7 +66,7 @@ def delete_module(mod_id):
         single=True)
 
     if module is None:
-        # request not found
+        # module not found
         abort(404)
 
     # create a cursor so we can group multiple statements into a transaction

--- a/src/brutus-api/brutus_api/views/requests.py
+++ b/src/brutus-api/brutus_api/views/requests.py
@@ -67,7 +67,7 @@ def requests():
     # create the request in the database
     request_id = insert_db(
         g.db,
-        'INSERT INTO request (session_id, status, input) VALUES (?, ?)',
+        'INSERT INTO request (session_id, status, input) VALUES (?, ?, ?)',
         (session_id, 'created', input_data['text']))
 
     g.db.commit()

--- a/src/brutus-api/brutus_api/views/sessions.py
+++ b/src/brutus-api/brutus_api/views/sessions.py
@@ -1,0 +1,36 @@
+from flask import g, request, json, abort
+
+from brutus_api.app import app
+from brutus_api.database import query_db
+
+
+@app.route('/api/session')
+def sessions():
+    """
+    Get sessions.
+    """
+
+    # retrieve all modules
+    sessions = map(dict, query_db(g.db, 'SELECT * FROM session'))
+    return json.jsonify(list(sessions))
+
+
+@app.route('/api/session/<int:session_id>')
+def get_session(session_id):
+    """
+    Get a session.
+    """
+
+    # retrieve the session
+    session = query_db(
+        g.db,
+        'SELECT * FROM session WHERE id = ?',
+        (session_id, ),
+        single=True)
+
+    if session is None:
+        # session not found
+        abort(404)
+
+    # return the module data
+    return json.jsonify(dict(session))

--- a/src/webClient/index.js
+++ b/src/webClient/index.js
@@ -1,6 +1,6 @@
 // No framework makes for a sloppy js file :(
 
-const baseURL = 'http://cse5914-218011.nitrousapp.com:5000';
+const baseURL = 'http://localhost:5000';
 
 // speech recognition
 var SpeechRecognition = SpeechRecognition || webkitSpeechRecognition;


### PR DESCRIPTION
This pull request adds support for sessions in the `brutus-api` project.

* When POSTing a new request to `/api/request` you can optionally include a `session_id` parameter for an open session (i.e. `{"text": "...", "session_id": 5}`). If you do the backend will attempt to use it to process the request otherwise it will automatically create a new session.
* There is a new read-only API at `/api/session` that can be used to query session status.
* Subsequent requests to a backend module will include module meta-data in a `data` key (i.e. `{"input": {"text": "..."}, "data": {"last_answer": 5}}`).
* Responses from backend modules can optionally include meta-data for the backend to store in the session (see above). If they do then the session will be kept open. If they don't then the session will be closed.
* Requests that are part of an open session will be sent to the same module as the first request.