### PR TITLE
Catch backend task errors and display them to the user.

### DIFF
--- a/src/brutus-api/brutus_api/tasks.py
+++ b/src/brutus-api/brutus_api/tasks.py
@@ -51,7 +51,7 @@ def process_request(request_id):
 
     # update the request status
     db.execute(
-        'UPDATE request SET status = \'started\' WHERE id = ?',
+        "UPDATE request SET status = 'started' WHERE id = ?",
         (request_id, ))
 
     db.commit()
@@ -117,12 +117,12 @@ def process_request(request_id):
         else:
             # close the session
             db.execute(
-                'UPDATE session SET status = \'closed\' WHERE id = ?',
+                "UPDATE session SET status = 'closed' WHERE id = ?",
                 (session_id, ))
 
         # update the request with a finished state
         db.execute(
-            'UPDATE request SET status = \'finished\', output = ? WHERE id = ?',
+            "UPDATE request SET status = 'finished', output = ? WHERE id = ?",
             (response_data['output']['text'], request_id))
 
         db.commit()
@@ -130,12 +130,12 @@ def process_request(request_id):
     except Exception as e:
         # update the request with a failed state and generic error message
         db.execute(
-            'UPDATE request SET status = \'failed\', output = ? WHERE id = ?',
+            "UPDATE request SET status = 'failed', output = ? WHERE id = ?",
             ("Something went wrong. Try again a little later.", request_id))
 
         # close the session
         db.execute(
-            'UPDATE session SET status = \'closed\' WHERE id = ?',
+            "UPDATE session SET status = 'closed' WHERE id = ?",
             (session_id, ))
 
         # commit the changes

--- a/src/webClient/index.js
+++ b/src/webClient/index.js
@@ -147,6 +147,8 @@ const startPolling = (jobID) => {
             if (obj.status === 'closed') {
               updateSession(undefined);
             }
+
+            outputBox.style.backgroundColor = "white";
             writeToBox(outputText, outputBox);
             sayThing(outputText);
             buttonStates.ready();
@@ -155,8 +157,10 @@ const startPolling = (jobID) => {
           //buttonStates.processing();
           setTimeout(poll(), timeout);
         } else if (obj.status === 'failed') {
-          writeToBox('Request failed at processing stage', outputBox);
           buttonStates.ready();
+          outputBox.style.backgroundColor = "pink";
+          writeToBox(obj.output.text, outputBox);
+          sayThing(obj.output.text);
         }
       })
       .catch(console.log);


### PR DESCRIPTION
This pull request improves the error handling of `process_task` tasks in the backend.

* Catch any exceptions thrown in `process_task` once we've retrieved the relevant `session` and `request` rows from the database.
* Modify the web client to display the request output with a different style when a `request` fails.